### PR TITLE
Add simple startup menu

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -1,0 +1,58 @@
+print(r"""
+---------------------------------------------------------------
+|                         thermo scientific                   |
+---------------------------------------------------------------
+
+Start
+ ├── Session Creation
+Preparation
+ ├── Session Setup
+ ├── Square Selection
+ ├── Image Selection
+ ├── Template Definition
+Execution
+ └── Automated Acquisition
+
+---------------------------------------------------------------
+|                           Session                            |
+|-------------------------------------------------------------|
+| General session settings                                    |
+|-------------------------------------------------------------|
+| Session name: giovanni.mariotta_20240603_101250_59         |
+| Grid type:  ○ Holey carbon  ● Lacey carbon  ○ Holey gold    |
+| Geometry type:  ● Square  ○ Hexagonal  ○ Unknown            |
+| Session type:  ● Automated  ○ Manual                        |
+| Acquisition Mode:  ● Accurate  ○ Faster                     |
+| Tilted Acquisition: (checkbox, not visible)                 |
+|-------------------------------------------------------------|
+| Output settings                                             |
+|-------------------------------------------------------------|
+| Image format:  ● MRC  ○ TIFF                                |
+| Output folder:                                              |
+|   C:\\Users\\giovanni.mariotta\\OneDrive - Thermo Fisher S... |
+|   [x] Set as default storage folder                         |
+|-------------------------------------------------------------|
+| Email settings                                              |
+| Email recipients:                                           |
+|   [                    ]  [Test]                            |
+|-------------------------------------------------------------|
+|                        [ Apply ]                            |
+---------------------------------------------------------------
+
+Messages
+---------------------------------------------------------------
+Filtering:  [0 Error(s)]  [0 Notification(s)]
+
+Status
+---------------------------------------------------------------
+EPU Assistant
+  ● llama3
+  ○ llama3Multi
+
+[ Ask To AI Assistant ]  [ ] Content-Aware
+""")
+
+input("Press Enter to start the snake game...")
+
+from snake import main
+main()


### PR DESCRIPTION
## Summary
- add a `menu.py` script displaying the provided UI
- start the existing `snake` game once the user presses Enter

## Testing
- `pytest -q`
- `python -m py_compile menu.py`


------
https://chatgpt.com/codex/tasks/task_e_684179a4fce483309015fb092e1f3f62