### PR TITLE
Add Jira chatbot option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+jira_config.json

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ pip install -r requirements.txt
 
 ## Running
 
-Use `menu.py` to choose which game to play:
+Use `menu.py` to choose which program to run:
 
 ```bash
 python menu.py
 ```
 
-You can pick between the classic Snake game and a minimal Doom-like
-first-person demo. In the Doom demo press the space bar to shoot water
-from your pistol. Press `q` to exit a running game.
+You can pick between the classic Snake game, a minimal Doom-like
+first-person demo, or a simple Jira chatbot. The chatbot uses the MCP
+server to query Jira issues. On first run it asks for your Jira URL,
+username and API token and saves them in `jira_config.json`. In the Doom
+demo press the space bar to shoot water from your pistol. Press `q` to
+exit a running game.

--- a/jira_bot.py
+++ b/jira_bot.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+from jira import JIRA
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.server import Context
+
+CONFIG_FILE = Path("jira_config.json")
+
+
+def load_config() -> dict:
+    """Load JIRA credentials from a config file or prompt the user."""
+    if CONFIG_FILE.exists():
+        with CONFIG_FILE.open() as f:
+            return json.load(f)
+
+    base_url = input("JIRA URL (e.g. https://your-domain.atlassian.net): ").strip()
+    username = input("JIRA username/email: ").strip()
+    api_token = input("JIRA API token: ").strip()
+
+    data = {"base_url": base_url, "username": username, "api_token": api_token}
+    with CONFIG_FILE.open("w") as f:
+        json.dump(data, f)
+    print(f"Saved credentials to {CONFIG_FILE}")
+    return data
+
+
+def start_server() -> None:
+    creds = load_config()
+    jira = JIRA(server=creds["base_url"], basic_auth=(creds["username"], creds["api_token"]))
+
+    server = FastMCP(name="JiraBot")
+
+    @server.tool()
+    def search_issues(jql: str, ctx: Context) -> str:
+        """Return summaries for the first few issues matching JQL."""
+        issues = jira.search_issues(jql, maxResults=5)
+        if not issues:
+            return "No issues found."
+        return "\n".join(f"{i.key}: {i.fields.summary}" for i in issues)
+
+    server.run()
+
+
+def main() -> None:
+    try:
+        start_server()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/menu.py
+++ b/menu.py
@@ -9,8 +9,9 @@ def main() -> None:
         print("Select a game:")
         print("1) Snake")
         print("2) Mini Doom")
-        print("3) Quit")
-        choice = input("Enter choice [1-3]: ").strip()
+        print("3) Jira Chatbot")
+        print("4) Quit")
+        choice = input("Enter choice [1-4]: ").strip()
         if choice == "1":
             from snake import main as snake_main
             snake_main()
@@ -18,6 +19,9 @@ def main() -> None:
             from doom import main as doom_main
             doom_main()
         elif choice == "3":
+            from jira_bot import main as jira_main
+            jira_main()
+        elif choice == "4":
             print("Goodbye!")
             break
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,11 @@ requires-python = ">=3.7"
 dependencies = [
     "windows-curses; sys_platform == 'win32'",
     "pygame",
+    "jira",
+    "mcp[cli]",
 ]
 
 [project.scripts]
 snake = "snake:main"
 doom_demo = "doom:main"
+jira_bot = "jira_bot:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 # External dependencies for the terminal games
 windows-curses; sys_platform == 'win32'
 pygame
+jira
+mcp[cli]


### PR DESCRIPTION
## Summary
- add a simple Jira chatbot using MCP
- store credentials in `jira_config.json`
- add new menu entry for the chatbot
- update dependencies and package config
- document the new feature
- ignore config in `.gitignore`

## Testing
- `python menu.py <<EOF
4
EOF`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6841853591388330a26fdc2b61057a26