### PR TITLE
Add baby bear enemy to Doom demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ You can pick between the classic Snake game, a minimal Doom-like
 first-person demo, or a simple Jira chatbot. The chatbot uses the MCP
 server to query Jira issues. On first run it asks for your Jira URL,
 username and API token and saves them in `jira_config.json`. In the Doom
-demo press the space bar to shoot water from your pistol. Press `q` to
+demo press the space bar to shoot water from your pistol. A baby bear
+enemy roams the map—if you bump into it, the demo ends. Press `q` to
 exit a running game.


### PR DESCRIPTION
## Summary
- add a baby bear enemy to the Doom demo
- show the baby bear sprite and collision logic
- mention the baby bear in the README

## Testing
- `flake8 || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842acb3e7f4833090a8cab73fa473df